### PR TITLE
fix: handle unexpected props during inflate

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -73,7 +73,13 @@ export function inflate(props: FlatProps): Props {
             if (!(c[i] in l)) l[c[i]] = {};
             l = l[c[i]];
         }
-        l[c[c.length - 1]] = val;
+
+        try {
+            l[c[c.length - 1]] = val;
+        } catch (e) {
+            if (typeof res._weird === 'undefined') res._weird = {};
+            res._weird[key] = val;
+        }
     }
     return res;
 }


### PR DESCRIPTION
I was running into a case where `getAllSinks()` was throwing an error due to an unexpected couple of props. This PR is more of a workaround than anything in that it will just drop any props it can't handle into a new property called `_weird`. That keeps all the information available to any clients who need it while also not breaking the current way of doing things too much.

```json
{
  ...
  "api.dbus.ReserveDevice1": "Audio1",
  "api.dbus.ReserveDevice1.Priority": "-20",
  ...
}
```